### PR TITLE
Basic profiling & simplify prediction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
 name = "clnt"
 version = "0.1.0"
 dependencies = [
+ "coarse-prof",
  "comn",
  "console_error_panic_hook",
  "instant",
@@ -282,6 +283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "coarse-prof"
+version = "0.2.4"
+source = "git+https://github.com/leod/coarse-prof.git#66758eb4ddbcb5f58caf89f947d17d3abb7218a5"
+dependencies = [
+ "instant",
+ "log",
 ]
 
 [[package]]
@@ -314,6 +324,7 @@ dependencies = [
 name = "comn"
 version = "0.1.0"
 dependencies = [
+ "coarse-prof",
  "instant",
  "log",
  "nalgebra",

--- a/clnt/Cargo.toml
+++ b/clnt/Cargo.toml
@@ -23,6 +23,7 @@ quicksilver = { version = "=0.4.0-alpha0.5", features = ["web-sys"] }
 mint = "0.5"
 instant = "0.1"
 pareen = { git = "https://github.com/leod/pareen.git", features = ["easer"] }
+coarse-prof = { git = "https://github.com/leod/coarse-prof.git" }
 
 comn = { path = "../comn" }
 

--- a/clnt/src/prediction.rs
+++ b/clnt/src/prediction.rs
@@ -220,16 +220,23 @@ impl Prediction {
                         }
                         _ => Some((*id, server.clone())),
                     },
-                    join::Item::Left(_, _) => None,
-                    join::Item::Right(id, server) => {
-                        // Server has a new entity, make sure to replay
-                        // prediction so that we include it. Might be that there
-                        // is a better way to go about it, because this will
-                        // replay prediction too often.
-                        if Self::is_predicted(my_player_id, server) {
+                    join::Item::Left(_, predicted) => {
+                        if Self::is_predicted(my_player_id, predicted) {
+                            // An entity that we predicted (most likely the
+                            // PlayerEntity) no longer exists in the authorative
+                            // state. Make sure to replay.
                             error += MIN_PREDICTION_ERROR_FOR_REPLAY;
                         }
-
+                        None
+                    }
+                    join::Item::Right(id, server) => {
+                        if Self::is_predicted(my_player_id, server) {
+                            // Server has a new entity, make sure to replay
+                            // prediction so that we include it. Might be that
+                            // there is a better way to go about it, because
+                            // this will replay prediction too often.
+                            error += MIN_PREDICTION_ERROR_FOR_REPLAY;
+                        }
                         Some((*id, server.clone()))
                     }
                 }

--- a/clnt/src/prediction.rs
+++ b/clnt/src/prediction.rs
@@ -213,7 +213,7 @@ impl Prediction {
                             Some((
                                 *id,
                                 comn::Entity::Player(comn::PlayerEntity {
-                                    pos: predicted.pos + (server.pos - predicted.pos) * 0.2,
+                                    pos: Self::correct_point(predicted.pos, server.pos),
                                     ..server.clone()
                                 }),
                             ))
@@ -237,6 +237,17 @@ impl Prediction {
             .collect();
 
         error
+    }
+
+    fn correct_point(predicted: comn::Point, server: comn::Point) -> comn::Point {
+        let delta = server - predicted;
+
+        if delta.norm() < 0.01 || delta.norm() > 200.0 {
+            server
+        } else {
+            // Smoothly correct prediction over time
+            predicted + delta * 0.2
+        }
     }
 
     fn add_predicted_entity(entities: &mut comn::EntityMap, entity: comn::Entity) {

--- a/clnt/src/render.rs
+++ b/clnt/src/render.rs
@@ -323,7 +323,6 @@ pub fn render_game(
                 gfx.stroke_circle(&circle, Color::BLACK);
             }
             comn::Entity::Food(food) => {
-                let origin: mint::Vector2<f32> = food.pos(time).coords.into();
                 let transform = rect_to_transform(&food.rect(time));
 
                 let rect = Rectangle::new(Vector::new(-0.5, -0.5), Vector::new(1.0, 1.0));

--- a/comn/Cargo.toml
+++ b/comn/Cargo.toml
@@ -15,3 +15,5 @@ nalgebra = { version = "0.21", features = ["serde-serialize", "mint"] }
 instant = "0.1"
 log = "0.4"
 rand = "0.7"
+
+coarse-prof = { git = "https://github.com/leod/coarse-prof.git" }

--- a/comn/src/game/run.rs
+++ b/comn/src/game/run.rs
@@ -171,6 +171,8 @@ impl Game {
         context: &mut RunContext,
     ) -> GameResult<()> {
         if let Some((entity_id, ent)) = self.get_player_entity(player_id) {
+            coarse_prof::profile!("run_player_input");
+
             let mut ent = ent.clone();
 
             self.run_player_entity_input(

--- a/serv/src/runner.rs
+++ b/serv/src/runner.rs
@@ -22,7 +22,7 @@ use crate::{
     webrtc::{self, RecvMessageRx, SendMessageTx},
 };
 
-pub const PLAYER_INPUT_BUFFER: usize = 2;
+pub const PLAYER_INPUT_BUFFER: usize = 1;
 pub const MAX_PLAYER_INPUT_AGE: f32 = 1.0;
 pub const MAX_DIFF_TICKS: u32 = 50;
 


### PR DESCRIPTION
- Integrate `coarse-prof` to find hotspots
  - Running player input is super slow in debug mode, but instant in release mode
- Change prediction log so it stores only predicted entities, not the whole state
- Apply prediction correction only when there are actual errors

=> Can run at ~40FPS in debug mode, so development is much faster.